### PR TITLE
btrfs no space cache

### DIFF
--- a/preload.sh
+++ b/preload.sh
@@ -81,7 +81,7 @@ losetup "$LOOP_DEV" "$IMAGE"
 partprobe "$LOOP_DEV"
 
 mkdir -p "/mnt/$APP_ID"
-mount "${LOOP_DEV}p6" "/mnt/$APP_ID"
+mount -t btrfs -o nospace_cache "${LOOP_DEV}p6" "/mnt/$APP_ID"
 
 # Resize partition's filesystem
 # btrfs resize does not work reliably, fallback to hoping there is enough space


### PR DESCRIPTION
Sometimes after adding space with dd,  btrfs partition could not be expanded because of insufficient space.

A few users had hit this, and a user confirmed the problem went away after he rebooted, which makes me think it is some sort of caching issue.

This is an attempt to fix the issue by disabling free space cache on btrfs. As I have not been able to reproduce this, this is more like a guess at this point.