### PR TITLE
Update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,6 @@ Download a OS image from the Resin dashboard and then run with docker:
   export API_TOKEN=... # copy from dashboard preferences
   export APP_ID=... # id of your application (you can see it on dashboard URL when you visit your app page)
   export PATH_TO_IMAGE=/path/to/resin.img
-  docker run -it -v /var/run/docker.sock:/var/run/docker.sock -e API_TOKEN=$API_TOKEN -e API_HOST=https://api.resin.io -e REGISTRY_HOST=registry.resin.io -e APP_ID=$APP_ID -e IMAGE=/img/resin.img -v $PATH_TO_IMAGE:/img/resin.img --privileged resin/resin-preload
+  docker run -it -v /var/run/docker.sock:/var/run/docker.sock -e API_TOKEN=$API_TOKEN -e API_HOST=https://api.resin.io -e REGISTRY_HOST=registry.resin.io -e APP_ID=$APP_ID -v $PATH_TO_IMAGE:/img/resin.img --privileged resin/resin-preload
 ```
 After running this, the `/path/to/resin.img` file will include the latest app container for your application.

--- a/README.md
+++ b/README.md
@@ -4,17 +4,11 @@ Script for preloading resin device images with a user application container.
 
 Using this will allow images with supervisor version above 1.0.0 to run the user application without connectivity, and without the need to download the container.
 
-## System requirements
-Tested on Ubuntu 14.04.
+## Building from source
 
-Requires the following executables:
-  * curl
-  * jq
-  * docker
-  * losetup
-  * partprobe
-  * bash
-  * btrfs
+```bash
+  docker build -t resin/resin-preload .
+```
 
 ## Usage
 

--- a/preload.sh
+++ b/preload.sh
@@ -16,7 +16,8 @@ test "$API_TOKEN" -o "$API_KEY" || { echo >&2 "API_TOKEN or API_KEY must be set"
 test "$API_HOST" || { echo >&2 "API_HOST must be set"; exit 1; }
 test "$REGISTRY_HOST" || { echo >&2 "REGISTRY_HOST must be set"; exit 1; }
 test "$APP_ID" || { echo >&2 "APP_ID must be set"; exit 1; }
-test "$IMAGE" || { echo >&2 "IMAGE must be set"; exit 1; }
+
+IMAGE=${IMAGE:-"/img/resin.img"}
 test -e "$IMAGE" || { echo >&2 "IMAGE file does not exist"; exit 1; }
 
 function cleanup {


### PR DESCRIPTION
Remove system requirements as they are not needed.

Explain how to build docker image from source.

Remove IMAGE env var from documentation and make "/img/resin.img" the default value.