### PR TITLE
19-fix-for-newer-resinos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:1.7-dind
+FROM docker:1.10-dind
 
 RUN apk update && apk add --no-cache bash curl jq parted btrfs-progs docker util-linux
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # resin-preload-image-script
 
-Script for preloading resin device images with a user application container.
+Script for preloading resin.io OS images (`.img`) with a user application container.
 
 Using this will allow images with supervisor version above 1.0.0 to run the user application without connectivity, and without the need to download the container.
+
+>**NOTE:** This will only work on resinOS versions between 1.2 and 2.0. For versions lower than 1.2 you will need to checkout commit `5d6d4607bffc98acdf649ce5328e2079dfb9c3d9` of this repo and then follow the steps below. 
 
 ## Building from source
 
@@ -13,11 +15,11 @@ Using this will allow images with supervisor version above 1.0.0 to run the user
 ## Usage
 
 This script requires the following environment variables to be set:
-  * `IMAGE`: The path to the OS image to modify
-  * `APP_ID`: ID of the App that will be assigned to the device. It can be extracted from the URL in the Resin dashboard, for instance `https://dashboard.resinstaging.io/apps/2167` means the `APP_ID` is `2167`.
-  * `REGISTRY_HOST`: Docker registry from which to download the image. If unsure, use `registry.resin.io`.
-  * `API_TOKEN`: Authentication token for Resin, taken from the [preferences page](https://dashboard.resinstaging.io/preferences?tab=details). Alternatively, you can use an `API_KEY` variable with an API key from a config.json file or the [SDK](https://github.com/resin-io/resin-sdk/blob/master/DOCUMENTATION.md#resin.models.application.getApiKey).
-  * `API_HOST`: Address of the Resin API. If unsure, use `https://api.resin.io`.
+  * `IMAGE`: The path to the OS image you downloaded for the APP you want to target.
+  * `APP_ID`: ID of the App that will be assigned to the device. It can be extracted from the URL in the Resin dashboard, for instance `https://dashboard.resin.io/apps/2167` means the `APP_ID` is `2167`.
+  * `API_TOKEN`: Authentication token for Resin, taken from the [preferences page](https://dashboard.resin.io/preferences?tab=details). 
+
+**Note:** Before running the example below, make sure that you have successfully pushed to the APP and that the `Application commit` is the correct version of the code you intend to preload.
 
 ## Example
 
@@ -31,3 +33,8 @@ Download a OS image from the Resin dashboard and then run with docker:
 ```
 
 The `/path/to/resin.img` file, will now have the latest version of your application preloaded.
+
+## Additional Options
+* `REGISTRY_HOST`: Docker registry from which to download the image. If unsure, use `registry.resin.io`.
+* Alternatively to `API_TOKEN`, you can use an `API_KEY` variable with an API key from a config.json file or the [SDK](https://github.com/resin-io/resin-sdk/blob/master/DOCUMENTATION.md#resin.models.application.getApiKey).
+* `API_HOST`: Address of the Resin API. If unsure, use `https://api.resin.io`.

--- a/preload.sh
+++ b/preload.sh
@@ -42,6 +42,7 @@ fi ) | jq --arg registryHost "$REGISTRY_HOST" '.d[0] |
         [ { appId: .id, commit, imageRepo: $imageRepo, imageId: $imageId, env: $env } ]' > "$TMP_APPS_JSON"
 
 IMAGE_REPO=$(jq -r '.[0].imageRepo' "$TMP_APPS_JSON")
+echo "Loading the following image: " $IMAGE_REPO
 
 # Get application container size
 
@@ -52,6 +53,7 @@ jq '.[]' | awk '{print "'$REGISTRY_HOST'/v1/images/" $1 "/json"}' | \
 xargs -r -n 1 curl -I -s | \
 grep 'X-Docker-Size' | \
 awk '{s+=$2} END {print int(s / 1000000)}')
+echo "container size: " $CONTAINER_SIZE "MB"
 
 # Size will be increased by 110% of container size
 IMG_ADD_SPACE=$(expr $CONTAINER_SIZE / 100 + 300)
@@ -100,7 +102,7 @@ if [ -d "/mnt/$APP_ID/docker" ]; then
 else
     DOCKER_DIR=/mnt/$APP_ID/rce
 fi
-docker -d -s btrfs -g "$DOCKER_DIR" -p "$DOCKER_PID" -H "unix://$DOCKER_SOCK" &
+docker daemon -s btrfs -g "$DOCKER_DIR" -p "$DOCKER_PID" -H "unix://$DOCKER_SOCK" &
 
 echo "Waiting for Docker to start..."
 while [ ! -e "$DOCKER_SOCK" ]; do


### PR DESCRIPTION
Connects to #19

This PR makes the preloader script actually work on newer resinOS versions. Previously it would not work on any resinOS version greater than v1.2 because of a change in the docker on disk format introduced in docker 1.10. 

This PR changes the dind base image to use docker 1.10, and as such will now break preloading on resinOS versions older than v1.2.