### PR TITLE
Add support for Resin OS 2.0 AUFS storage driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,16 @@ Script for preloading resin.io OS images (`.img`) with a user application contai
 
 Using this will allow images with supervisor version above 1.0.0 to run the user application without connectivity, and without the need to download the container.
 
->**NOTE:** This will only work on resinOS versions between 1.2 and 2.0. For versions lower than 1.2 you will need to checkout commit `5d6d4607bffc98acdf649ce5328e2079dfb9c3d9` of this repo and then follow the steps below. 
+## Known Issues
+
+### Version Compatibility
+
+This version will only work for Resin OS versions 1.2 and later.
+For versions earlier than 1.2 you will need to checkout commit `5d6d4607bffc98acdf649ce5328e2079dfb9c3d9` of this repo and then follow the steps below. 
+
+### BTRFS Support
+
+Since Docker for Mac removed support for the BTRFS storage driver (see [docker/for-mac/issues/388](https://github.com/docker/for-mac/issues/388)), preloading images prior to Resin OS 2.0 will require the older [Docker toolbox](https://docs.docker.com/toolbox/toolbox_install_mac/) setup with [VirtualBox](https://www.virtualbox.org/) to function properly.
 
 ## Building from source
 

--- a/preload.sh
+++ b/preload.sh
@@ -3,117 +3,356 @@
 set -e
 set -o pipefail
 
-test "$API_TOKEN" -o "$API_KEY" || { echo >&2 "API_TOKEN or API_KEY must be set"; exit 1; }
-test "$APP_ID" || { echo >&2 "APP_ID must be set"; exit 1; }
-
 IMAGE=${IMAGE:-"/img/resin.img"}
-test -e "$IMAGE" || { echo >&2 "IMAGE file does not exist"; exit 1; }
-
 API_HOST=${API_HOST:-"https://api.resin.io"}
 REGISTRY_HOST=${REGISTRY_HOST:-"registry.resin.io"}
 
-function cleanup {
-        rm $TMP_APPS_JSON || true
-	test "$DOCKER_PID" && kill $(cat $DOCKER_PID)
-	echo "Waiting for Docker to stop..."
-	while [ -e "$DOCKER_PID" ]; do
-		sleep 1
-	done
-        test -d "/tmp/docker-$APP_ID" && rm -rf "/tmp/docker-$APP_ID"
-        test "`mount | grep \"/mnt/$APP_ID\"`" && umount "/mnt/$APP_ID"
-        test -d "/mnt/$APP_ID" && rmdir "/mnt/$APP_ID"
+# Check if credentials have been set
+test "$API_TOKEN" -o "$API_KEY" || { echo >&2 "API_TOKEN or API_KEY must be set"; exit 1; }
+test "$APP_ID" || { echo >&2 "APP_ID must be set"; exit 1; }
+# Check if .img file exists
+test -e "$IMAGE" || { echo >&2 "IMAGE file does not exist"; exit 1; }
+
+# Variables
+APPS_JSON=
+IMAGE_REPO=
+IMAGE_ID=
+CONTAINER_SIZE=
+IMAGE_ADD_SPACE=
+
+# Mountpoints
+ROOTFS_MNT="/mnt/$APP_ID-rootfs"
+APPFS_MNT="/mnt/$APP_ID"
+
+# Docker vars
+DOCKER_TMP="/tmp/docker-$APP_ID"
+DOCKER_PID="${DOCKER_TMP}/docker.pid"
+DOCKER_SOCK="${DOCKER_TMP}/docker.sock"
+DOCKER_DIR=
+
+# Log to stderr to avoid interfering
+# with function output
+function log() {
+    echo >&2 $@
+}
+
+function cleanup() {
+
+    log "Cleaning up"
+
+    if [[ -e $DOCKER_PID ]]; then
+        log "Waiting for Docker to stop"
+        kill $(cat $DOCKER_PID)
+        while [[ -e "$DOCKER_PID" ]]; do
+            sleep 1
+        done
+    fi
+
+    if [[ -d $DOCKER_TMP ]]; then
+        log "Removing Docker tmp files"
+        rm -rfv $DOCKER_TMP || true
+    fi
+
+    if [[ $(mount | grep "$ROOTFS_MNT") ]]; then
+        log "Unmounting rootfs from $ROOTFS_MNT"
+        umount -v $ROOTFS_MNT || true
+        test -d $ROOTFS_MNT && rmdir $ROOTFS_MNT
+    fi
+
+    if [[ $(mount | grep "$APPFS_MNT") ]]; then
+        log "Unmounting application from $APPFS_MNT"
+        umount -v $APPFS_MNT || true
+        test -d $APPFS_MNT && rmdir $APPFS_MNT
+    fi
+
+    sync
+    sleep 2
+    log "Unmapping loopback interfaces"
+    losetup -D || true
+
 }
 
 trap cleanup EXIT
 
-# Get app data and write to temporary file
+# Transform a version number into a contiguous number for comparison
+# Usage: version 2.0.0-beta7
+# Output: 002000000
+function version() {
+    echo "$@" | sed 's/^(\d+(\.\d+)*)/\1/' | awk -F. '{ printf("10#%03d%03d%03d\n", $1,$2,$3); }';
+}
 
-TMP_APPS_JSON=$(mktemp)
+# Compare two version numbers
+# Usage: version_ge 1.2.0 2.0.0
+# Example:
+# if version_ge $first_version $second_version; then
+#   echo "$first_version >= $second_version !"
+# fi
+function version_ge() {
+    [[ $(version $1) -ge $(version $2) ]]
+}
 
-( if test "$API_TOKEN"; then
-        curl -sH "Authorization: Bearer $API_TOKEN" "$API_HOST/ewa/application($APP_ID)?\$expand=environment_variable"
-elif test "$API_KEY"; then
-        curl "$API_HOST/ewa/application($APP_ID)?\$expand=environment_variable&apikey=$API_KEY"
-fi ) | jq --arg registryHost "$REGISTRY_HOST" '.d[0] |
-        (.git_repository | split("/") | .[1] | rtrimstr(".git")) as $repoName |
+# Fetch application metadata
+# NOTE: Depends on ($API_TOKEN | $API_HOST & $API_KEY),
+# $APP_ID, and $REGISTRY_HOST being set
+function get_app_data() {
+    local response=
+    if test "$API_TOKEN"; then
+        log "Using API_TOKEN"
+        response=$(curl -sH "Authorization: Bearer $API_TOKEN" "$API_HOST/v2/application($APP_ID)?\$expand=environment_variable")
+    elif test "$API_KEY"; then
+        log "Using API_KEY"
+        response=$(curl "$API_HOST/v2/application($APP_ID)?\$expand=environment_variable&apikey=$API_KEY")
+    fi
+    echo $response | jq --arg registryHost "$REGISTRY_HOST" '.d[0] |
+        (.app_name) as $repoName |
         ($repoName + "/" + .commit) as $imageRepo |
         ($registryHost + "/" + $imageRepo) as $imageId |
-	((.environment_variable // []) | map({(.name): .value}) | add) as $env |
-        [ { appId: .id, commit, imageRepo: $imageRepo, imageId: $imageId, env: $env } ]' > "$TMP_APPS_JSON"
+        ((.environment_variable // []) | map({(.name): .value}) | add) as $env |
+        [ { appId: .id, commit, imageRepo: $imageRepo, imageId: $imageId, env: $env } ]'
+}
 
-IMAGE_REPO=$(jq -r '.[0].imageRepo' "$TMP_APPS_JSON")
-echo "Loading the following image: " $IMAGE_REPO
+# Fetch container metadata
+function get_container_size() {
+    echo $(curl -s "$REGISTRY_HOST/v1/images/$IMAGE_ID/ancestry" | \
+        jq '.[]' | awk '{print "'$REGISTRY_HOST'/v1/images/" $1 "/json"}' | \
+        xargs -r -n 1 curl -I -s | \
+        grep 'X-Docker-Size' | \
+        awk '{s+=$2} END {print int(s / 1000000)}')
+}
 
-# Get application container size
+# Usage: map_loop <image> <part_no>
+function map_loop() {
+    # Find the next free /dev/loop
+    local LOOPDEVICE=$(losetup -f)
+    # Get partition offset & size
+    local PART_START=$(get_partition_start $2 B)
+    local PART_END=$(get_partition_end $2 B)
+    local PART_SIZE=$(( $PART_END - $PART_START + 1 ))
+    # Map image partition to device
+    log "Mapping $IMAGE $PART_START:$PART_SIZE to $LOOPDEVICE"
+    losetup $LOOPDEVICE $1 --offset $PART_START --sizelimit $PART_SIZE >&2
+    echo $LOOPDEVICE
+}
 
-IMAGE_ID=$(curl -s "$REGISTRY_HOST/v1/repositories/$IMAGE_REPO/tags/latest" | jq -r '.')
+# Usage: unmap_loop <loopdevice>
+function unmap_loop() {
+    log "Unmapping" $1
+    losetup -d $1
+}
 
-CONTAINER_SIZE=$(curl -s "$REGISTRY_HOST/v1/images/$IMAGE_ID/ancestry" | \
-jq '.[]' | awk '{print "'$REGISTRY_HOST'/v1/images/" $1 "/json"}' | \
-xargs -r -n 1 curl -I -s | \
-grep 'X-Docker-Size' | \
-awk '{s+=$2} END {print int(s / 1000000)}')
-echo "container size: " $CONTAINER_SIZE "MB"
+# Mount the image's rootfs to $ROOTFS_MNT
+# Usage: mount_rootfs <device>
+function mount_rootfs() {
+    log
+    log "Mounting rootfs from $1 to" $ROOTFS_MNT
+    # Create the mount path, then sync & sleep
+    # to ensure it exists before mounting
+    mkdir -p $ROOTFS_MNT
+    sync
+    sleep 2
+    # Mount the rootfs from partition 2
+    mount -o loop,ro $1 $ROOTFS_MNT
+}
 
-# Size will be increased by 110% of container size
-IMG_ADD_SPACE=$(expr $CONTAINER_SIZE / 100 + 300)
+function unmount_rootfs() {
+    log "Unmounting rootfs from" $ROOTFS_MNT
+    umount -v $ROOTFS_MNT || true
+    test -d $ROOTFS_MNT && rmdir $ROOTFS_MNT
+}
 
-# Add zero bytes to image to be able to resize partitions
+# Get the Resin OS version info by mounting the root partition
+# and setting the variables from `/etc/os-release`
+# Usage: get_resin_os_version <mount_path>
+# Available variables:
+#
+# ID="resin-os"
+# NAME="Resin OS"
+# VERSION="2.0.0-beta.7"
+# VERSION_ID="2.0-beta.7"
+# PRETTY_NAME="Resin OS 2.0.0-beta.7"
+# RESIN_BOARD_REV=82eeb8b
+# META_RESIN_REV=0870520
+# SLUG=raspberrypi3
+# MACHINE=raspberrypi3
+function get_resin_os_version() {
 
-dd if=/dev/zero bs=1M count="$IMG_ADD_SPACE" >> "$IMAGE"
+    local LOOPDEVICE=$(map_loop $IMAGE 2)
+    mount_rootfs $LOOPDEVICE
 
-# Resize partition
+    log
+    local OS_RELEASE="${1}/etc/os-release"
+    log "Sourcing release info from" $OS_RELEASE
+    source $OS_RELEASE
 
-# Calculate new partition end by getting current partition end and adding the additional spzce.
-PART_END=$(parted -s -m "$IMAGE" p | tail -n 1 | awk -F ':' '{print $3 + '$IMG_ADD_SPACE'}')
+    log "Detected" $PRETTY_NAME
 
-# Resize partition table
-# Both extended and logical partition must be increased
-parted -s "$IMAGE" resizepart 4 "${PART_END}MB" resizepart 6 "${PART_END}MB"
+    log
+    log "id:" $ID
+    log "name:" $NAME
+    log "version:" $VERSION
+    log "version_id:" $VERSION_ID
+    log "pretty_name:" $PRETTY_NAME
+    log "resin_board_rev:" $RESIN_BOARD_REV
+    log "meta_resin_rev:" $META_RESIN_REV
+    log "slug:" $SLUG
+    log "machine:" $MACHINE
+    log
 
-# mount partition
+    unmount_rootfs
+    unmap_loop $LOOPDEVICE
 
-PART_START=$(parted -s -m "$IMAGE" unit B p | tail -n 1 | sed 's/[^:]:\([^B]*\).*/\1/')
+}
 
-mkdir -p "/mnt/$APP_ID"
-# make sure directory exists before mounting to it
-sync
-sleep 2
-mount -t btrfs -o "nospace_cache,loop,rw,offset=${PART_START}" "$IMAGE" "/mnt/$APP_ID"
+# Usage: expand_image <image_path>
+function expand_image() {
+    # Size will be increased by 110% of container size
+    IMAGE_ADD_SPACE=$(($CONTAINER_SIZE / 100 + 300))
+    log "Expanding image by" $IMAGE_ADD_SPACE "MB"
+    # Add zero bytes to image to be able to resize partitions
+    dd if=/dev/zero bs=1M count="$IMAGE_ADD_SPACE" >> "$IMAGE"
+}
 
-# Resize partition's filesystem
-btrfs filesystem resize max "/mnt/$APP_ID"
+# Get the start offset (in bytes) of a partition by partition number
+# Usage: get_partition_start <part_no> <unit>
+function get_partition_start() {
+    # We need to skip the first two lines of `parted` output
+    local LINENO=$(($1 + 2))
+    # Extract value & strip the unit
+    local PATTERN="s/[^:]:\([^${2}]*\).*/\1/"
+    parted -s -m $IMAGE unit $2 p | sed -n "${LINENO}p" | sed $PATTERN
+}
 
-# write apps.json
-# keep only the fields we need from TMP_APPS_JSON
-jq '.[0] | [ { appId, commit, imageId, env } ]' $TMP_APPS_JSON > "/mnt/$APP_ID/apps.json"
+# Get the end offset (in bytes) of a partition by partition number
+# Usage: get_partition_end <part_no> <unit>
+function get_partition_end() {
+    # We need to skip the first two lines of `parted` output
+    local LINENO=$(($1 + 2))
+    # Extract value & strip the unit
+    local PATTERN="s/[^:]:[^${2}]*${2}:\([^${2}]*\).*/\1/"
+    parted -s -m $IMAGE unit $2 p | sed -n "${LINENO}p" | sed $PATTERN
+}
 
-mkdir -p "/tmp/docker-$APP_ID"
-DOCKER_PID="/tmp/docker-$APP_ID/docker.pid"
-DOCKER_SOCK="/tmp/docker-$APP_ID/docker.sock"
+# Resizes partition 4 & 6 by <add_space> (in MB)
+# Usage: expand_partitions <add_space>
+function expand_partitions() {
+    local PART_END=$(get_partition_end 6 MB)
+    local NEW_PART_END=$(($PART_END + $1))
+    log "Expanding extended partition 4 by" $1 "MB"
+    log "Expanding logical partition 6 by" $1 "MB"
+    parted -s "$IMAGE" resizepart 4 "${NEW_PART_END}MB" resizepart 6 "${NEW_PART_END}MB"
+}
 
-# start docker daemon that uses rce/docker partition for storage
-if [ -d "/mnt/$APP_ID/docker" ]; then
+# Resize ext4 filesystem
+function expand_ext4() {
+    local LOOPDEVICE=$(map_loop $IMAGE 6)
+    log "Using" $LOOPDEVICE
+
+    # For ext4, we'll have to keep it unmounted to resize
+    log "Resizing filesystem"
+    e2fsck -f $LOOPDEVICE && resize2fs -f $LOOPDEVICE
+    mount -t ext4 -o rw $LOOPDEVICE $APPFS_MNT
+}
+
+# Resize BTRFS filesystem
+function expand_btrfs() {
+    log
+    # For btrfs we'll need to mount the fs, and setup the loop device manually,
+    local LOOPDEVICE=$(map_loop $IMAGE 6)
+    log "Using" $LOOPDEVICE
+
+    log "Mounting application fs to" $APPFS_MNT
+    mount -t btrfs -o nospace_cache,rw $LOOPDEVICE $APPFS_MNT
+
+    log "Resizing filesystem"
+    btrfs filesystem resize max $APPFS_MNT
+}
+
+# Write apps.json to file $1
+# Usage: write_apps_json <path>
+function write_apps_json() {
+    echo $APPS_JSON | jq '.[0] | [ { appId, commit, imageId, env } ]' > $1
+}
+
+# Start the docker daemon
+# Usage: start_docker_daemon <filesystem_type>
+function start_docker_daemon() {
+    mkdir -p $DOCKER_TMP
+
     # If this preload script was ran before implementing the rce/docker fix,
     # make sure you cleanup
-    rm -rf /mnt/$APP_ID/rce
+    if [[ -d "${APPFS_MNT}/docker" ]]; then
+        log "Removing" "${APPFS_MNT}/rce"
+        rm -rfv "${APPFS_MNT}/rce"
+        DOCKER_DIR="${APPFS_MNT}/docker"
+    else
+        DOCKER_DIR="${APPFS_MNT}/rce"
+    fi
 
-    DOCKER_DIR=/mnt/$APP_ID/docker
-else
-    DOCKER_DIR=/mnt/$APP_ID/rce
-fi
-docker daemon -s btrfs -g "$DOCKER_DIR" -p "$DOCKER_PID" -H "unix://$DOCKER_SOCK" &
+    docker daemon -s $1 -g "$DOCKER_DIR" -p "$DOCKER_PID" -H "unix://$DOCKER_SOCK" &
 
-echo "Waiting for Docker to start..."
-while [ ! -e "$DOCKER_SOCK" ]; do
+    log "Waiting for Docker to start..."
+    while [ ! -e "$DOCKER_SOCK" ]; do
         sleep 1
-done
+    done
+    log "Docker started"
+}
 
-echo "Pulling image..."
-IMAGE_ID=$(jq -r '.[0].imageId' "/mnt/$APP_ID/apps.json")
+# Fetch & process app / image / container data, set $APPS_JSON,
+# $IMAGE_REPO, $IMAGE_ID, and $CONTAINER_SIZE
+log "Fetching application data"
+log "Using API host" $API_HOST
+log "Using Registry host" $REGISTRY_HOST
+APPS_JSON=$(get_app_data)
+IMAGE_REPO=$(echo $APPS_JSON | jq -r '.[0].imageRepo' | tr '[:upper:]' '[:lower:]')
+
+log "Fetching image data" $IMAGE_REPO
+IMAGE_ID=$(curl -s "$REGISTRY_HOST/v1/repositories/$IMAGE_REPO/tags/latest" | jq -r '.')
+log "Image ID:" $IMAGE_ID
+
+log "Fetching container data"
+CONTAINER_SIZE=$(get_container_size)
+log "Container size:" $CONTAINER_SIZE "MB"
+
+get_resin_os_version $ROOTFS_MNT
+
+parted -s $IMAGE unit MB p
+
+# Resize partition
+expand_image $IMAGE
+expand_partitions $IMAGE_ADD_SPACE
+
+parted -s $IMAGE unit MB p
+
+log "Creating mountpoint" $APPFS_MNT
+# Create the mount path, then sync & sleep
+# to ensure it exists before mounting
+mkdir -p $APPFS_MNT
+sync
+sleep 2
+
+# Check for Resin OS version,
+# and switch from BTRFS to EXT4 for 2.0.0+,
+# then expand & mount the application filesystem
+log "Expanding filesystem"
+if version_ge $VERSION "2.0.0"; then
+    log "Using EXTFS"
+    expand_ext4
+    start_docker_daemon aufs
+else
+    log "Using BTRFS"
+    expand_btrfs
+    start_docker_daemon btrfs
+fi
+
+# write apps.json
+# keep only the fields we need from APPS_JSON
+write_apps_json "${APPFS_MNT}/apps.json"
+
+log "Pulling image..."
+IMAGE_ID=$(jq -r '.[0].imageId' "${APPFS_MNT}/apps.json" | tr '[:upper:]' '[:lower:]')
 docker -H "unix://$DOCKER_SOCK" pull "$IMAGE_ID"
 
-echo "Docker images loaded:"
+log "Docker images loaded:"
 docker -H "unix://$DOCKER_SOCK" images --all
 
-echo "Done."
+log "Done."


### PR DESCRIPTION
Connects to #18
So, here goes the second edition of #22 (with @Page-'s comments addressed):

**Changes:**
- Normalised indentation to 4 spaces
- ~~Added `multipath-tools` package, enabling use of `kpathx` to map a partitioned loopdevice (thanks @lurch for the tip)~~
- Moved most parts into (semi-) reusable functions / variables
- Added image OS version detection to switch between storage drivers
- Added filesystem expansion logic for ext4
- Added more comments and log output (which goes to `stderr` to prevent mangling function output)

**To Do:**
- [x] Update `README.md` with usage & limitations

<details>
<summary><b>Sample output</b></summary>
<pre><code>
Fetching application data
Using API host https://api.resin.io
Using Registry host registry.resin.io
Using API\_TOKEN
Fetching image data preloadtest/0a9fb1ab20c38acfd00500aa404cc13c7d2471d2
Image ID: bf7a4c842666b34ef33c92a126370447352c2e27919529c24cd3cb419de337fa
Fetching container data
Container size: 187 MB

Mapping /img/resin.img to loopback blockdevice
add map loop0p1 (249:0): 0 81920 linear /dev/loop0 8192
add map loop0p2 (249:1): 0 614400 linear /dev/loop0 90112
add map loop0p3 (249:2): 0 614400 linear /dev/loop0 704512
add map loop0p4 (249:3): 0 2 linear /dev/loop0 1318912
add map loop0p5 : 0 40960 linear /dev/loop0 1327104
add map loop0p6 : 0 2097152 linear /dev/loop0 1376256

Mounting rootfs to /mnt/16971-rootfs

Sourcing release info from /mnt/16971-rootfs/etc/os-release
Detected Resin OS 2.0.0-beta.6

id: resin-os
name: Resin OS
version: 2.0.0-beta.6
version\_id: 2.0-beta.6
pretty_name: Resin OS 2.0.0-beta.6
resin\_board\_rev: ec079bb
meta\_resin\_rev: b836d0b
slug: raspberrypi3
machine: raspberrypi3

Unmounting rootfs from /mnt/16971-rootfs
umount: /mnt/16971-rootfs unmounted
Unmapping /img/resin.img from loopback blockdevice
del devmap : loop0p6
del devmap : loop0p5
del devmap : loop0p4
del devmap : loop0p3
del devmap : loop0p2
del devmap : loop0p1
loop deleted : /dev/loop0
Model:  (file)
Disk /img/resin.img: 5250MB
Sector size (logical/physical): 512B/512B
Partition Table: msdos
Disk Flags:

Number  Start   End     Size    Type      File system  Flags
 1      4.19MB  46.1MB  41.9MB  primary   fat16        boot, lba
 2      46.1MB  361MB   315MB   primary   ext3
 3      361MB   675MB   315MB   primary
 4      675MB   5089MB  4414MB  extended               lba
 5      679MB   700MB   21.0MB  logical   ext4         lba
 6      705MB   5089MB  4384MB  logical   ext4

Expanding image by 301 MB
301+0 records in
301+0 records out
Expanding partition 4 & 6 by 301 MB
Model:  (file)
Disk /img/resin.img: 5566MB
Sector size (logical/physical): 512B/512B
Partition Table: msdos
Disk Flags:

Number  Start   End     Size    Type      File system  Flags
 1      4.19MB  46.1MB  41.9MB  primary   fat16        boot, lba
 2      46.1MB  361MB   315MB   primary   ext3
 3      361MB   675MB   315MB   primary
 4      675MB   5390MB  4715MB  extended               lba
 5      679MB   700MB   21.0MB  logical   ext4         lba
 6      705MB   5390MB  4685MB  logical   ext4

Creating mountpoint /mnt/16971
Expanding filesystem
Using EXTFS
Resizing filesystem
e2fsck 1.43 (17-May-2016)
Pass 1: Checking inodes, blocks, and sizes
Pass 2: Checking directory structure
Pass 3: Checking directory connectivity
Pass 4: Checking reference counts
Pass 5: Checking group summary information
resin-data: 8291/540672 files (0.1% non-contiguous), 65981/1070399 blocks
resize2fs 1.43 (17-May-2016)
Resizing the filesystem on /dev/loop7 to 1143885 (4k) blocks.
The filesystem on /dev/loop7 is now 1143885 (4k) blocks long.

Removing /mnt/16971/rce
Waiting for Docker to start...
INFO Graph migration to content-addressability took 0.00 seconds
WARN Running modprobe bridge br\_netfilter failed with message: modprobe: WARNING: Module bridge not found in directory /lib/modules/4.4.41-boot2docker
modprobe: WARNING: Module br\_netfilter not found in directory /lib/modules/4.4.41-boot2docker, error: exit status 1
WARN Running modprobe nf\_nat failed with message: 'modprobe: WARNING: Module nf\_nat not found in directory /lib/modules/4.4.41-boot2docker', error: exit status 1
INFO Default bridge (docker0) is assigned with an IP address 172.18.0.0/16. Daemon option --bip can be used to set a preferred IP address
WARN Your kernel does not support cgroup blkio weight
WARN Your kernel does not support cgroup blkio weight\_device
INFO Loading containers: start.
INFO Loading containers: done.
INFO Daemon has completed initialization
INFO Docker daemon                                 commit=20f81dd execdriver=native-0.2 graphdriver=aufs version=1.10.3
INFO API listen on /tmp/docker-16971/docker.sock
Docker started
Pulling image...
Using default tag: latest
Pulling repository registry.resinstaging.io/preloadtest/0a9fb1ab20c38acfd00500aa404cc13c7d2471d2
bf7a4c842666: Pull complete
db95e11b2339: Pull complete
feb32a246d3f: Pull complete
0090b12af17d: Pull complete
497a6e56afb7: Pull complete
1c5fe43284aa: Pull complete
fecf0f028aef: Pull complete
bf5229a2c613: Pull complete
8df53f94a9de: Pull complete
b1aa402d36ed: Pull complete
71dccefd6488: Pull complete
1b88d4b6faf5: Pull complete
00caa23f024c: Pull complete
5707fe0f2f0b: Pull complete
79858bb65e83: Pull complete
28f975603a54: Pull complete
f1a706b3dde8: Pull complete
688fcd44afa5: Pull complete
022a8b787879: Pull complete
7ed7684b2b4f: Pull complete
05b1e05d464d: Pull complete
2c5c37bc89b5: Pull complete
Status: Downloaded newer image for registry.resinstaging.io/preloadtest/0a9fb1ab20c38acfd00500aa404cc13c7d2471d2:latest
registry.resinstaging.io/preloadtest/0a9fb1ab20c38acfd00500aa404cc13c7d2471d2: this image was pulled from a legacy registry.  Important: This registry version will not be supported in future versions of docker.
Docker images loaded:
REPOSITORY                                                                      TAG                 IMAGE ID            CREATED             SIZE
registry.resinstaging.io/preloadtest/0a9fb1ab20c38acfd00500aa404cc13c7d2471d2   latest              6dd293484b2c        46 hours ago        454.3 MB
resin/armv7hf-supervisor                                                        latest              eef8cf4afe02        7 weeks ago         67.55 MB
resin/armv7hf-supervisor                                                        v2.8.3              eef8cf4afe02        7 weeks ago         67.55 MB
Done
Cleaning up
Waiting for Docker to stop
INFO Processing signal 'terminated'
Removing Docker tmp files
removed directory: '/tmp/docker-16971'
Unmounting rootfs from /mnt/16971-rootfs
umount: /mnt/16971-rootfs: mountpoint not found
Unmounting application from /mnt/16971
umount: /mnt/16971 unmounted
Unmapping loopback interfaces
</code></pre>
</details>
