### PR TITLE
Fix container size arithmetic (invalid float)

### DIFF
--- a/src/preload.sh
+++ b/src/preload.sh
@@ -207,7 +207,7 @@ function get_resin_os_version() {
 # Usage: expand_image <image_path>
 function expand_image() {
     # Size will be increased by 110% of container size
-    IMAGE_ADD_SPACE=$(($CONTAINER_SIZE * 1.1))
+    IMAGE_ADD_SPACE=$(($CONTAINER_SIZE * 110 / 100))
     log "Expanding image by" $IMAGE_ADD_SPACE "MB"
     # Add zero bytes to image to be able to resize partitions
     dd if=/dev/zero bs=1M count="$IMAGE_ADD_SPACE" >> "$IMAGE"


### PR DESCRIPTION
Connects to: #31, #30 

Fixes a grave error made in #30; floats aren't supported in these expressions and throw a syntax error.