### PR TITLE
Default apps.json env & config to empty object instead of null

### DIFF
--- a/src/preload.sh
+++ b/src/preload.sh
@@ -109,7 +109,7 @@ function get_app_data() {
         ($registryHost + "/" + $imageRepo | ascii_downcase) as $imageId |
         ((.environment_variable // []) | map(select((.name|startswith("RESIN_"))==false)) | map({(.name): .value}) | add) as $env |
         ((.environment_variable // []) | map(select(.name|startswith("RESIN_"))) | map({(.name): .value}) | add) as $config |
-        [ { appId: .id, commit, imageRepo: $imageRepo, imageId: $imageId, env: $env, config: $config } ]'
+        [ { appId: .id, commit, imageRepo: $imageRepo, imageId: $imageId, env: ($env // {}), config: ($config // {}) } ]'
 }
 
 # Fetch container metadata


### PR DESCRIPTION
This fixes an issue where the supervisor (v3.0.1+) won't start up the app without network access.

Connects to: #34 