### PR TITLE
preload.sh: Remove use of realpath

### DIFF
--- a/preload.sh
+++ b/preload.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT=$(basename ${BASH_SOURCE[0]})
-DIRNAME=$(realpath $(dirname ${BASH_SOURCE[0]}))
+DIRNAME=$(dirname ${BASH_SOURCE[0]})
 CONTAINER_NAME="resin-image-preloader"
 
 function cleanup() {


### PR DESCRIPTION
The `realpath` is not available by default on several operating systems,
and hence this removes its usage to determine the dirname, as it should work without it as well.