### PR TITLE
src/preload.sh: Enable auto-repair for e2fsck

### DIFF
--- a/src/preload.sh
+++ b/src/preload.sh
@@ -276,7 +276,17 @@ function expand_ext4() {
 
     # For ext4, we'll have to keep it unmounted to resize
     log "Resizing filesystem"
-    e2fsck -f $LOOPDEVICE && resize2fs -f $LOOPDEVICE
+    e2fsck -p -f "$LOOPDEVICE"
+    local status=$?
+    if [[ $status -ne 0 && $status -le 2 ]]; then
+        log "e2fsck: File system errors corrected"
+    elif [[ $status -gt 2 ]]; then
+        log "e2fsck: File system errors could not be corrected"
+        exit 1
+    else
+        log "e2fsck: File system OK"
+    fi
+    resize2fs -f $LOOPDEVICE
     mount -t ext4 -o rw $LOOPDEVICE $APPFS_MNT
 }
 


### PR DESCRIPTION
This enables e2fsck to automatically repair issues that can safely
be fixed without human interaction, allowing the preloader to fail
properly if the file system is corrupted.

Previously e2fsck would print that it needs human interaction and
allow the preloader to continue, causing out-of-disk-space errors
if subsequently, the filesystem could not be expanded.

Connects To: #54
Change-Type: patch